### PR TITLE
Corrected path to required file

### DIFF
--- a/lib/oneview-sdk/resource/api500/synergy/storage_system.rb
+++ b/lib/oneview-sdk/resource/api500/synergy/storage_system.rb
@@ -9,7 +9,7 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-require_relative '../../api300/synergy/storage_system'
+require_relative '../../api500/c7000/storage_system'
 
 module OneviewSDK
   module API500


### PR DESCRIPTION
### Description
Corrected import in `api500/Synergy/StorageSystem`

### Issues Resolved
- #226 cannot require oneview-sdk because the code is using non-require'd code #2

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass (`$ rake test`).
- [ ] Changes are documented in the CHANGELOG.
